### PR TITLE
add missing props to <form>

### DIFF
--- a/dist/camelCase.d.ts
+++ b/dist/camelCase.d.ts
@@ -560,7 +560,7 @@ export interface HTMLOwnAttributesBy {
     figure: {};
     font: Pick<HTMLCommonAttributes, "color">;
     footer: {};
-    form: Pick<HTMLCommonAttributes, "accept" | "acceptCharset" | "action">;
+    form: Pick<HTMLCommonAttributes, "accept" | "acceptCharset" | "action" | "autoComplete" | "encType" | "method" | "name" | "noValidate" | "rel" | "target">;
     frame: {};
     frameset: {};
     h1: {};

--- a/dist/native.d.ts
+++ b/dist/native.d.ts
@@ -167,7 +167,7 @@ export interface HTMLOwnAttributesBy {
     figure: {};
     font: Pick<HTMLCommonAttributes, "color">;
     footer: {};
-    form: Pick<HTMLCommonAttributes, "accept" | "accept-charset" | "action">;
+    form: Pick<HTMLCommonAttributes, "accept" | "accept-charset" | "action" | "autocomplete" | "enctype" | "method" | "name" | "novalidate" | "rel" | "target">;
     frame: {};
     frameset: {};
     h1: {};

--- a/src/ts/Attributes_camelCase.ts
+++ b/src/ts/Attributes_camelCase.ts
@@ -645,7 +645,7 @@ export interface HTMLOwnAttributesBy {
     figure: {};
     font: Pick<HTMLCommonAttributes, "color">;
     footer: {};
-    form: Pick<HTMLCommonAttributes, "accept" | "acceptCharset" | "action">;
+    form: Pick<HTMLCommonAttributes, "accept" | "acceptCharset" | "action" | "autoComplete" | "encType" | "method" | "name" | "noValidate" | "rel" | "target">;
     frame: {};
     frameset: {};
     h1: {};
@@ -826,7 +826,7 @@ export interface SVGGlobalAttributes extends Omit<SVGGlobalAttributes_core, "tab
 // - SVG presentation attributes - //
 
 /** All SVG presentation attributes in camelCase. They can also be used as CSS properties. */
-export interface SVGPresentationAttributes extends Pick<SVGCommonAttributes, 
+export interface SVGPresentationAttributes extends Pick<SVGCommonAttributes,
     | "alignmentBaseline"
     | "baselineShift"
     | "clip"

--- a/src/ts/Attributes_native.ts
+++ b/src/ts/Attributes_native.ts
@@ -200,7 +200,7 @@ export interface HTMLOwnAttributesBy {
     figure: {};
     font: Pick<HTMLCommonAttributes, "color">;
     footer: {};
-    form: Pick<HTMLCommonAttributes, "accept" | "accept-charset" | "action">;
+    form: Pick<HTMLCommonAttributes, "accept" | "accept-charset" | "action" | "autocomplete" | "enctype" | "method" | "name" | "novalidate" | "rel" | "target">;
     frame: {};
     frameset: {};
     h1: {};
@@ -365,7 +365,7 @@ export type SVGAttributesBy = { [Tag in SVGTags]: SVGAttributes<Tag>; };
 export interface SVGGlobalAttributes extends SVGGlobalAttributes_core {}
 
 /** All SVG presentation attributes in native case. They can also be used as CSS properties. */
-export interface SVGPresentationAttributes extends Pick<SVGCommonAttributes_core, 
+export interface SVGPresentationAttributes extends Pick<SVGCommonAttributes_core,
     | "alignment-baseline"
     | "baseline-shift"
     | "clip"


### PR DESCRIPTION
The `<form>` element is missing some attributes in the type declarations (compared to [the MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/form)).

This PR adds them, hopefully correctly and without duplicates.