### PR TITLE
declare id attribute in SVG as string only instead of string | number

### DIFF
--- a/dist/core.d.ts
+++ b/dist/core.d.ts
@@ -895,7 +895,7 @@ interface HTMLCommonAttributes_core {
 
 /** SVG attributes in native case available on all SVG elements. */
 interface SVGGlobalAttributes_core extends DataAttributes {
-    "id": string | number;
+    "id": string;
     "class": string;
     "lang": string;
     "style": string | CSSProperties;
@@ -1016,7 +1016,7 @@ interface SVGCommonAttributes_core {
     "horiz-adv-x": string | number;
     "horiz-origin-x": string | number;
     "horiz-origin-y": string | number;
-    "id": string | number;
+    "id": string;
     "ideographic": string | number;
     "image-rendering": string;
     "in": "SourceGraphic" | "SourceAlpha" | "BackgroundImage" | "BackgroundAlpha" | "FillPaint" | "StrokePaint" | AnyString;

--- a/src/ts/core/SVGAttributes.ts
+++ b/src/ts/core/SVGAttributes.ts
@@ -16,7 +16,7 @@ import { CSSBlendMode, CSSColorNames, CSSProperties } from "../CSSProperties";
 
 /** SVG attributes in native case available on all SVG elements. */
 export interface SVGGlobalAttributes_core extends DataAttributes {
-    "id": string | number;
+    "id": string;
     "class": string;
     "lang": string;
     "style": string | CSSProperties;
@@ -152,7 +152,7 @@ export interface SVGCommonAttributes_core {
     "horiz-adv-x": string | number;
     "horiz-origin-x": string | number;
     "horiz-origin-y": string | number;
-    "id": string | number;
+    "id": string;
     "ideographic": string | number;
     "image-rendering": string;
     "in": "SourceGraphic" | "SourceAlpha" | "BackgroundImage" | "BackgroundAlpha" | "FillPaint" | "StrokePaint" | AnyString;
@@ -218,7 +218,7 @@ export interface SVGCommonAttributes_core {
     "refX": "left" | "center" | "right" | AnyString | number;
     "refY": "left" | "center" | "right" | AnyString | number;
     "rel": string;
-    "requiredExtensions": string; 
+    "requiredExtensions": string;
     "requiredFeatures": string; // Deprecated.
     "result": string;
     "rotate": "auto" | "auto-reverse" | AnyString | number;


### PR DESCRIPTION
Currently the `id` attribute for `HTMLAttributes` is declared to be of type `string`, but for `SVGAttributes` it's declared to be of type `string | number`.

In a vacuum this isn't a problem. But in an SSG I'm building using this repo for attribute type checking, this difference keeps causing me issues time and time again where my functions for transforming prop objects will fail to typecheck, I'd guess because of the existence of SVG attributes with the same name as HTML attributes (e.g. `<a>`).

This PR declares the SVG `id` to be just a `string`, matching the HTML `id`.

From the MDN docs on [HTML `id`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/id) and [SVG `id`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/id), nothing seems to be an indication in favor of the difference. If there's something I've missed, please let me know. Otherwise, if this was just a mistake on your part, I'd be grateful for a merge. :)